### PR TITLE
feat: #ensure_valid_syntax on tax ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,59 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "memchr"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "tax_ids"
 version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "regex",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+lazy_static = "1.4.0"
+regex = "1.10.4"

--- a/src/eu_vat.rs
+++ b/src/eu_vat.rs
@@ -26,6 +26,16 @@ impl TaxIdType for EUVat {
 
         pattern.is_match(value)
     }
+
+    fn country_code_from(&self, tax_country_code: &str) -> String {
+        let country_code = match tax_country_code {
+            "XI" => "GB",
+            "EL" => "GR",
+            _ => tax_country_code,
+        };
+
+        country_code.to_string()
+    }
 }
 
 #[cfg(test)]

--- a/src/eu_vat.rs
+++ b/src/eu_vat.rs
@@ -1,6 +1,18 @@
+mod syntax;
+
+use lazy_static::lazy_static;
+use syntax::EU_VAT_PATTERNS;
 use crate::tax_id::TaxIdType;
 
 pub struct EUVat;
+
+lazy_static! {
+    #[derive(Debug)]
+    pub static ref COUNTRIES: Vec<&'static str> = vec![
+        "AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "EL", "ES", "FI", "FR", "HR", "HU",
+        "IE", "IT", "LT", "LU", "LV", "MT", "NL", "PL", "PT", "RO", "SE", "SI", "SK", "XI",
+    ];
+}
 
 impl TaxIdType for EUVat {
     fn name(&self) -> &'static str {
@@ -8,7 +20,748 @@ impl TaxIdType for EUVat {
     }
 
     fn ensure_valid_syntax(&self, value: &str) -> bool {
-        // Placeholder
-        value.len() > 5
+        let tax_country_code = &value[0..2].to_string();
+        let pattern = EU_VAT_PATTERNS.get(tax_country_code)
+            .expect("No pattern found for tax country code");
+
+        pattern.is_match(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_at_vat() {
+        let valid_vat_numbers = vec!["ATU12345678", "ATU87654321"];
+        let invalid_vat_numbers = vec!["AT12345678", "ATU1234567", "ATU123456789", "ATU1234567A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_be_vat() {
+        let valid_vat_numbers = vec!["BE0123456789", "BE0987654321"];
+        let invalid_vat_numbers = vec![
+            "BE123456789",
+            "BE012345678",
+            "BE01234567890",
+            "BE012345678A",
+        ];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_bg_vat() {
+        let valid_vat_numbers = vec!["BG123456789", "BG1234567890"];
+        let invalid_vat_numbers = vec!["BG12345678", "BG12345678901", "BG12345678A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_cy_vat() {
+        let valid_vat_numbers = vec!["CY12345678A", "CY98765432Z"];
+        let invalid_vat_numbers = vec!["CY12345678", "CY1234567A", "CY123456789A", "CY12345678AA"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_cz_vat() {
+        let valid_vat_numbers = vec!["CZ12345678", "CZ123456789", "CZ1234567890"];
+        let invalid_vat_numbers = vec!["CZ1234567", "CZ12345678901", "CZ12345678A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_de_vat() {
+        let valid_vat_numbers = vec!["DE123456789", "DE987654321"];
+        let invalid_vat_numbers = vec!["DE12345678", "DE1234567890", "DE12345678A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_dk_vat() {
+        let valid_vat_numbers = vec!["DK12345678"];
+        let invalid_vat_numbers = vec!["DK1234567", "DK123456789", "DK1234567A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_ee_vat() {
+        let valid_vat_numbers = vec!["EE101234567"];
+        let invalid_vat_numbers = vec!["EE10123456", "EE1012345678", "EE10123456A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_el_vat() {
+        let valid_vat_numbers = vec!["EL123456789"];
+        let invalid_vat_numbers = vec!["EL12345678", "EL1234567890", "EL12345678A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_es_vat() {
+        let valid_vat_numbers = vec!["ESX12345678", "ES12345678Z", "ESX1234567Z"];
+        let invalid_vat_numbers = vec!["ES12345678", "ESX123456789", "ES12345678ZZ"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_fi_vat() {
+        let valid_vat_numbers = vec!["FI12345678"];
+        let invalid_vat_numbers = vec!["FI1234567", "FI123456789", "FI1234567A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_fr_vat() {
+        let valid_vat_numbers = vec!["FR12345678901", "FRX1234567890"];
+        let invalid_vat_numbers = vec!["FR1234567890", "FR123456789012", "FR1234567890A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_hr_vat() {
+        let valid_vat_numbers = vec!["HR12345678901"];
+        let invalid_vat_numbers = vec!["HR1234567890", "HR123456789012", "HR1234567890A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_hu_vat() {
+        let valid_vat_numbers = vec!["HU12345678"];
+        let invalid_vat_numbers = vec!["HU1234567", "HU123456789", "HU1234567A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_ie_vat() {
+        let valid_vat_numbers = vec!["IE1234567A", "IE1A23456A", "IE1234567AA"];
+        let invalid_vat_numbers = vec!["IE1234567", "IE12345678A", "IE1234567AAA"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_it_vat() {
+        let valid_vat_numbers = vec!["IT12345678901"];
+        let invalid_vat_numbers = vec!["IT1234567890", "IT123456789012", "IT1234567890A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_lt_vat() {
+        let valid_vat_numbers = vec!["LT999999919", "LT999999919"];
+        let invalid_vat_numbers = vec!["LT12345678", "LT12345678901", "LT12345678A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_lu_vat() {
+        let valid_vat_numbers = vec!["LU12345678"];
+        let invalid_vat_numbers = vec!["LU1234567", "LU123456789", "LU1234567A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_lv_vat() {
+        let valid_vat_numbers = vec!["LV12345678901"];
+        let invalid_vat_numbers = vec!["LV1234567890", "LV123456789012", "LV1234567890A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_mt_vat() {
+        let valid_vat_numbers = vec!["MT12345678"];
+        let invalid_vat_numbers = vec!["MT1234567", "MT123456789", "MT1234567A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_nl_vat() {
+        let valid_vat_numbers = vec!["NL123456789B01"];
+        let invalid_vat_numbers = vec!["NL123456789B0", "NL123456789B012", "NL123456789B0A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_pl_vat() {
+        let valid_vat_numbers = vec!["PL1234567890"];
+        let invalid_vat_numbers = vec!["PL123456789", "PL12345678901", "PL123456789A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_pt_vat() {
+        let valid_vat_numbers = vec!["PT123456789"];
+        let invalid_vat_numbers = vec!["PT12345678", "PT1234567890", "PT12345678A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_ro_vat() {
+        let valid_vat_numbers = vec!["RO99999999", "RO999999999"];
+        let invalid_vat_numbers = vec!["RO12345678910", "RO12345678901", "RO12345678A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_se_vat() {
+        let valid_vat_numbers = vec!["SE123456789101"];
+        let invalid_vat_numbers = vec!["SE12345678900", "SE123456789002", "SE12345678900A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_si_vat() {
+        let valid_vat_numbers = vec!["SI12345678"];
+        let invalid_vat_numbers = vec!["SI1234567", "SI123456789", "SI1234567A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_sk_vat() {
+        let valid_vat_numbers = vec!["SK1234567890"];
+        let invalid_vat_numbers = vec!["SK123456789", "SK12345678901", "SK123456789A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
+    }
+
+    #[test]
+    fn test_xi_vat() {
+        let valid_vat_numbers = vec!["XI123456789", "XI987654321", "XIHA123", "XIGD123"];
+        let invalid_vat_numbers = vec!["XI12345678", "XI1234567890", "XI12345678A"];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
     }
 }

--- a/src/eu_vat.rs
+++ b/src/eu_vat.rs
@@ -6,4 +6,9 @@ impl TaxIdType for EUVat {
     fn name(&self) -> &'static str {
         "eu_vat"
     }
+
+    fn ensure_valid_syntax(&self, value: &str) -> bool {
+        // Placeholder
+        value.len() > 5
+    }
 }

--- a/src/eu_vat/syntax.rs
+++ b/src/eu_vat/syntax.rs
@@ -1,0 +1,50 @@
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use regex::Regex;
+
+lazy_static! {
+    pub static ref EU_VAT_PATTERNS: HashMap<String, Regex> = {
+        let mut m = HashMap::new();
+        m.insert("AT".to_string(), Regex::new(r"^ATU[0-9]{8}$").unwrap());
+        m.insert("BE".to_string(), Regex::new(r"^BE[0-1][0-9]{9}$").unwrap());
+        m.insert("BG".to_string(), Regex::new(r"^BG[0-9]{9,10}$").unwrap());
+        m.insert("CY".to_string(), Regex::new(r"^CY[0-69][0-9]{7}[A-Z]$").unwrap());
+        m.insert("CZ".to_string(), Regex::new(r"^CZ[0-9]{8,10}$").unwrap());
+        m.insert("DE".to_string(), Regex::new(r"^DE[0-9]{9}$").unwrap());
+        m.insert("DK".to_string(), Regex::new(r"^DK[0-9]{8}$").unwrap());
+        m.insert("EE".to_string(), Regex::new(r"^EE10[0-9]{7}$").unwrap());
+        m.insert("EL".to_string(), Regex::new(r"^EL[0-9]{9}$").unwrap());
+        m.insert("ES".to_string(), Regex::new(r"^ES([A-Z][0-9]{8}|[0-9]{8}[A-Z]|[A-Z][0-9]{7}[A-Z])$").unwrap());
+        m.insert("FI".to_string(), Regex::new(r"^FI[0-9]{8}$").unwrap());
+        m.insert("FR".to_string(), Regex::new(r"^FR[A-HJ-NP-Z0-9]{2}[0-9]{9}$").unwrap());
+        m.insert("HR".to_string(), Regex::new(r"^HR[0-9]{11}$").unwrap());
+        m.insert("HU".to_string(), Regex::new(r"^HU[0-9]{8}$").unwrap());
+        m.insert("IE".to_string(), Regex::new(r"^IE([0-9][A-Z][0-9]{5}|[0-9]{7}[A-Z]?)[A-Z]$").unwrap());
+        m.insert("IT".to_string(), Regex::new(r"^IT[0-9]{11}$").unwrap());
+        m.insert("LT".to_string(), Regex::new(r"^LT([0-9]{7}1[0-9]|[0-9]{10}1[0-9])$").unwrap());
+        m.insert("LU".to_string(), Regex::new(r"^LU[0-9]{8}$").unwrap());
+        m.insert("LV".to_string(), Regex::new(r"^LV[0-9]{11}$").unwrap());
+        m.insert("MT".to_string(), Regex::new(r"^MT[0-9]{8}$").unwrap());
+        m.insert("NL".to_string(), Regex::new(r"^NL[0-9]{9}B[0-9]{2}$").unwrap());
+        m.insert("PL".to_string(), Regex::new(r"^PL[0-9]{10}$").unwrap());
+        m.insert("PT".to_string(), Regex::new(r"^PT[0-9]{9}$").unwrap());
+        m.insert("RO".to_string(), Regex::new(r"^RO[1-9][0-9]{1,9}$").unwrap());
+        m.insert("SE".to_string(), Regex::new(r"^SE[0-9]{10}01$").unwrap());
+        m.insert("SI".to_string(), Regex::new(r"^SI[0-9]{8}$").unwrap());
+        m.insert("SK".to_string(), Regex::new(r"^SK[0-9]{10}$").unwrap());
+        m.insert("XI".to_string(), Regex::new(r"^XI([0-9]{9}|[0-9]{12}|(HA|GD)[0-9]{3})$").unwrap());
+        m
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eu_vat::COUNTRIES;
+    #[test]
+    fn test_each_eu_country_has_a_regex() {
+        let mut eu_regex_countries = EU_VAT_PATTERNS.keys().collect::<Vec<&String>>();
+        eu_regex_countries.sort();
+        assert_eq!(eu_regex_countries, *COUNTRIES);
+    }
+}

--- a/src/gb_vat.rs
+++ b/src/gb_vat.rs
@@ -6,4 +6,9 @@ impl TaxIdType for GBVat {
     fn name(&self) -> &'static str {
         "gb_vat"
     }
+
+    fn ensure_valid_syntax(&self, _value: &str) -> bool {
+        // Placeholder
+        true
+    }
 }

--- a/src/gb_vat.rs
+++ b/src/gb_vat.rs
@@ -12,6 +12,10 @@ impl TaxIdType for GBVat {
         let regex = Regex::new(r"^GB([0-9]{9}|[0-9]{12}|(HA|GD)[0-9]{3})$").unwrap();
         regex.is_match(value)
     }
+
+    fn country_code_from(&self, tax_country_code: &str) -> String {
+        tax_country_code.to_string()
+    }
 }
 
 #[cfg(test)]

--- a/src/gb_vat.rs
+++ b/src/gb_vat.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use crate::tax_id::TaxIdType;
 
 pub struct GBVat;
@@ -7,8 +8,51 @@ impl TaxIdType for GBVat {
         "gb_vat"
     }
 
-    fn ensure_valid_syntax(&self, _value: &str) -> bool {
-        // Placeholder
-        true
+    fn ensure_valid_syntax(&self, value: &str) -> bool {
+        let regex = Regex::new(r"^GB([0-9]{9}|[0-9]{12}|(HA|GD)[0-9]{3})$").unwrap();
+        regex.is_match(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gb_vat::GBVat;
+    use super::*;
+
+    #[test]
+    fn test_gb_vat() {
+        let valid_vat_numbers = vec![
+            "GB123456789",
+            "GB123456789101",
+            "GBHA123",
+            "GBGD123"
+        ];
+        let invalid_vat_numbers = vec![
+            "GB12345678",
+            "GB1234567891011",
+            "GBHA1234",
+            "GBGD1234",
+            "SE123456789101"
+        ];
+
+        for vat_number in valid_vat_numbers {
+            let valid_syntax = GBVat::ensure_valid_syntax(&GBVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                true,
+                "Expected valid VAT number, got invalid: {}",
+                vat_number
+            );
+        }
+
+        for vat_number in invalid_vat_numbers {
+            let valid_syntax = GBVat::ensure_valid_syntax(&GBVat, vat_number);
+            assert_eq!(
+                valid_syntax,
+                false,
+                "Expected invalid VAT number, got valid: {}",
+                vat_number
+            );
+        }
     }
 }

--- a/src/tax_id.rs
+++ b/src/tax_id.rs
@@ -1,35 +1,41 @@
+use std::process::id;
 use crate::eu_vat::EUVat;
 use crate::gb_vat::GBVat;
 use crate::errors::ValidationError;
+use crate::eu_vat;
 
 pub trait TaxIdType {
     fn name(&self) -> &'static str;
     fn ensure_valid_syntax(&self, value: &str) -> bool;
+    fn country_code_from(&self, tax_country_code: &str) -> String;
 }
 
 struct TaxId {
     value: String,
     country_code: String,
+    tax_country_code: String,
     local_value: String,
     id_type: &'static str,
 }
 
 impl TaxId {
     pub fn new(value: &str) -> Result<TaxId, ValidationError> {
-        let country_code = &value[0..2];
+        let tax_country_code = &value[0..2];
         let local_value = &value[2..];
-        let id_type: Box<dyn TaxIdType> = match country_code {
-            "SE" => Box::new(EUVat),
+
+        let id_type: Box<dyn TaxIdType> = match tax_country_code {
             "GB" => Box::new(GBVat),
-            _ => return Err(ValidationError::new("Unknown country code"))
+            _ if eu_vat::COUNTRIES.contains(&tax_country_code) => Box::new(EUVat),
+            _ => return Err(ValidationError::new("Unknown country code")),
         };
 
-        match id_type.ensure_valid_syntax(local_value) {
+        match id_type.ensure_valid_syntax(value) {
             false => Err(ValidationError::new("Invalid syntax")),
             true => Ok(TaxId {
                 id_type: id_type.name(),
                 value: value.to_string(),
-                country_code: country_code.to_string(),
+                tax_country_code: tax_country_code.to_string(),
+                country_code: id_type.country_code_from(tax_country_code),
                 local_value: local_value.to_string(),
             })
         }
@@ -47,20 +53,38 @@ mod tests {
 
     #[test]
     fn test_new_eu_vat() {
-        let tax_id= TaxId::new("SE1234567890").unwrap();
-        assert_eq!(tax_id.value(), "SE1234567890");
+        let tax_id= TaxId::new("SE123456789101").unwrap();
+        assert_eq!(tax_id.value(), "SE123456789101");
         assert_eq!(tax_id.country_code(), "SE");
-        assert_eq!(tax_id.local_value(), "1234567890");
+        assert_eq!(tax_id.local_value(), "123456789101");
+        assert_eq!(tax_id.id_type(), "eu_vat");
+    }
+
+    #[test]
+    fn test_new_gr_vat() {
+        let tax_id = TaxId::new("EL123456789").unwrap();
+        assert_eq!(tax_id.value(), "EL123456789");
+        assert_eq!(tax_id.country_code(), "GR");
+        assert_eq!(tax_id.local_value(), "123456789");
         assert_eq!(tax_id.id_type(), "eu_vat");
     }
 
     #[test]
     fn test_new_gb_vat() {
-        let tax_id = TaxId::new("GB123456789").unwrap();
-        assert_eq!(tax_id.value(), "GB123456789");
+        let tax_id = TaxId::new("GB591819014").unwrap();
+        assert_eq!(tax_id.value(), "GB591819014");
         assert_eq!(tax_id.country_code(), "GB");
-        assert_eq!(tax_id.local_value(), "123456789");
+        assert_eq!(tax_id.local_value(), "591819014");
         assert_eq!(tax_id.id_type(), "gb_vat");
+    }
+
+    #[test]
+    fn test_new_xi_vat() {
+        let tax_id = TaxId::new("XI591819014").unwrap();
+        assert_eq!(tax_id.value(), "XI591819014");
+        assert_eq!(tax_id.country_code(), "GB");
+        assert_eq!(tax_id.local_value(), "591819014");
+        assert_eq!(tax_id.id_type(), "eu_vat");
     }
 
     #[test]


### PR DESCRIPTION
### Why?

As a user of TaxIds I want to make as few government database lookups as possible. By making sure that the TaxId initializer only creates instances that adhere to the specific TaxId type syntaxes we can avoid any unnecessary lookups.

### What changed?

- Added the `tax_country_code`  field to the TaxId struct. This field is populated with the two-letter code at the start of the tax id value. IE: `"SE"` in `"SE123456789101"`. This was added due to cases where the TaxId value uses another two-letter iso code than the country. IE: `"GR"` & `"EL"` or `"GB"` and `"XI"`.
- Depending on the tax id value provided, TaxId initializer will route tp different `TaxIdTypes`. IE: `"SE123456789101"` will resolve to the `EUVat` while `"GBHA123"` will resolve to `GBVat`.
- Added regexes for EUVats & GBVat

