### PR TITLE
feat: convert verification data to json value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,7 @@ dependencies = [
  "regex",
  "reqwest",
  "roxmltree",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ regex = "1.10.4"
 reqwest = { version = "0.12.4", features = ["blocking"] }
 roxmltree = "0.19.0"
 chrono = "0.4.38"
+serde_json = "1.0.116"
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,14 +25,14 @@ impl Error for ValidationError {}
 #[derive(Debug)]
 pub enum VerificationError {
     HttpError(reqwest::Error),
-    ParsingError(roxmltree::Error),
+    XmlParsingError(roxmltree::Error),
 }
 
 impl fmt::Display for VerificationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             VerificationError::HttpError(err) => write!(f, "HTTP client error: {}", err),
-            VerificationError::ParsingError(err) => write!(f, "Parsing error: {}", err),
+            VerificationError::XmlParsingError(err) => write!(f, "XML parsing error: {}", err),
         }
     }
 }
@@ -41,7 +41,7 @@ impl Error for VerificationError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             VerificationError::HttpError(err) => Some(err),
-            VerificationError::ParsingError(err) => Some(err),
+            VerificationError::XmlParsingError(err) => Some(err),
         }
     }
 }

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -1,7 +1,6 @@
 use chrono::prelude::*;
 use crate::tax_id::TaxId;
 use crate::errors::VerificationError;
-use std::collections::HashMap;
 
 #[derive(Debug, PartialEq)]
 pub enum VerificationStatus {
@@ -14,11 +13,11 @@ pub enum VerificationStatus {
 pub struct Verification {
     performed_at: DateTime<Local>,
     status: VerificationStatus,
-    data: HashMap<String, String>,
+    data: serde_json::Value,
 }
 
 impl Verification {
-    pub fn new(status: VerificationStatus, data: HashMap<String, String>) -> Verification {
+    pub fn new(status: VerificationStatus, data: serde_json::Value) -> Verification {
         Verification {
             performed_at: Local::now(),
             status,
@@ -27,7 +26,7 @@ impl Verification {
     }
 
     pub fn status(&self) -> &VerificationStatus { &self.status }
-    pub fn data(&self) -> &HashMap<String, String> { &self.data }
+    pub fn data(&self) -> &serde_json::Value { &self.data }
 }
 
 pub trait Verifier {
@@ -43,13 +42,14 @@ pub trait Verifier {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
     use super::*;
 
     #[test]
     fn test_new_verification() {
         let verification = Verification::new(
             VerificationStatus::Verified,
-            HashMap::new(),
+            json!({})
         );
         assert_eq!(*verification.status(), VerificationStatus::Verified);
         assert_eq!(verification.performed_at.date_naive(), Local::now().date_naive());
@@ -63,13 +63,14 @@ mod tests {
         }
 
         fn parse_response(&self, response: String) -> Result<Verification, VerificationError> {
-            let mut hash = HashMap::new();
-            hash.insert("key".to_string(), "value".to_string());
+            let data = json!({
+                "key": "value"
+            });
 
             if response == "test" {
                 Ok(Verification::new(
                     VerificationStatus::Verified,
-                    hash
+                    data
                 ))
             } else { panic!("Unexpected response") }
         }


### PR DESCRIPTION
### Why?

Different government databases responds in different ways. UK's HMRC responds with JSON in nested address fields etc. Need a more flexible way to store raw response data.

Make Verification data a serde_json::Value type instead of a HashMap.

### What changed?
- Added serde_json
- Changed VIES to save XML response in serde_json::Value
- Represent missing values with option instead of empty string