### PR TITLE
fix: vies error handling

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,7 @@ pub enum VerificationError {
     HttpError(reqwest::Error),
     XmlParsingError(roxmltree::Error),
     JSONParsingError(serde_json::Error),
+    UnexpectedResponse(String),
 }
 
 impl fmt::Display for VerificationError {
@@ -35,6 +36,7 @@ impl fmt::Display for VerificationError {
             VerificationError::HttpError(err) => write!(f, "HTTP client error: {}", err),
             VerificationError::XmlParsingError(err) => write!(f, "XML parsing error: {}", err),
             VerificationError::JSONParsingError(err) => write!(f, "JSON parsing error: {}", err),
+            VerificationError::UnexpectedResponse(msg) => write!(f, "Unexpected response: {}", msg),
         }
     }
 }
@@ -45,6 +47,7 @@ impl Error for VerificationError {
             VerificationError::HttpError(err) => Some(err),
             VerificationError::XmlParsingError(err) => Some(err),
             VerificationError::JSONParsingError(err) => Some(err),
+            VerificationError::UnexpectedResponse(_) => None,
         }
     }
 }


### PR DESCRIPTION
### Why?

Improving VIES verifier error handling. Getting rid of panics and handling unexpected errors in better ways.

### What changed?
- Added a `VerificationError::UnexpectedResponse(String)` to group up errors that most likely shouldn't happen.
- Used the new error instead of `.expect()`