### PR TITLE
feat: verifiers clients use a generic verification response

### DIFF
--- a/src/verification.rs
+++ b/src/verification.rs
@@ -48,13 +48,13 @@ impl Verification {
 
 pub trait Verifier {
     fn verify(&self, tax_id: &TaxId) -> Result<Verification, VerificationError> {
-        let request = self.make_request(tax_id)?;
-        let verification = self.parse_response(request)?;
+        let response = self.make_request(tax_id)?;
+        let verification = self.parse_response(response)?;
         Ok(verification)
     }
-    fn make_request(&self, tax_id: &TaxId) -> Result<String, VerificationError>;
+    fn make_request(&self, tax_id: &TaxId) -> Result<VerificationResponse, VerificationError>;
 
-    fn parse_response(&self, _response: String) -> Result<Verification, VerificationError>;
+    fn parse_response(&self, response: VerificationResponse) -> Result<Verification, VerificationError>;
 }
 
 #[cfg(test)]
@@ -75,16 +75,19 @@ mod tests {
     struct TestVerifier;
 
     impl Verifier for TestVerifier {
-        fn make_request(&self, _tax_id: &TaxId) -> Result<String, VerificationError> {
-            Ok("test".to_string())
+        fn make_request(&self, _tax_id: &TaxId) -> Result<VerificationResponse, VerificationError> {
+            Ok(VerificationResponse::new(
+                200,
+                "test".to_string()
+            ))
         }
 
-        fn parse_response(&self, response: String) -> Result<Verification, VerificationError> {
+        fn parse_response(&self, response: VerificationResponse) -> Result<Verification, VerificationError> {
             let data = json!({
                 "key": "value"
             });
 
-            if response == "test" {
+            if response.status() == 200 && response.body() == "test" {
                 Ok(Verification::new(
                     VerificationStatus::Verified,
                     data

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -2,6 +2,23 @@ use chrono::prelude::*;
 use crate::tax_id::TaxId;
 use crate::errors::VerificationError;
 
+pub struct VerificationResponse {
+    status: u16,
+    body: String,
+}
+
+impl VerificationResponse {
+    pub fn new(status: u16, body: String) -> VerificationResponse {
+        VerificationResponse {
+            status,
+            body,
+        }
+    }
+
+    pub fn status(&self) -> u16 { self.status }
+    pub fn body(&self) -> &str { &self.body }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum VerificationStatus {
     Verified,


### PR DESCRIPTION
### Why?
Different government APIs respond differently with status codes and payload bodies. Logic for answering if a Tax Id is legit needs to be flexible on these parts.

Up to this point, the `Verifier` trait had its `make_request` return a string (representing the payload body) on success and `parse_response` take the same string.

Need the status code as well for more robust checks & the upcoming NO VAT logic.

### What changed?
- Added a VerificationResponse struct with status code and body
- Verifier trait and all verifiers now utilizes this response struct instead