### PR TITLE
feat: public syntax validation module

### DIFF
--- a/src/eu_vat/mod.rs
+++ b/src/eu_vat/mod.rs
@@ -1,7 +1,9 @@
 mod syntax;
 mod vies;
 
+use std::collections::HashMap;
 use lazy_static::lazy_static;
+use regex::Regex;
 use syntax::EU_VAT_PATTERNS;
 use crate::tax_id::TaxIdType;
 use crate::verification::{Verifier};
@@ -21,12 +23,8 @@ impl TaxIdType for EUVat {
         "eu_vat"
     }
 
-    fn ensure_valid_syntax(&self, value: &str) -> bool {
-        let tax_country_code = &value[0..2].to_string();
-        let pattern = EU_VAT_PATTERNS.get(tax_country_code)
-            .expect("No pattern found for tax country code");
-
-        pattern.is_match(value)
+    fn syntax_map(&self) -> &HashMap<String, Regex> {
+        &EU_VAT_PATTERNS
     }
 
     fn country_code_from(&self, tax_country_code: &str) -> String {
@@ -46,32 +44,32 @@ impl TaxIdType for EUVat {
 
 #[cfg(test)]
 mod tests {
+    use crate::errors::ValidationError;
     use super::*;
 
-    #[test]
-    fn test_at_vat() {
-        let valid_vat_numbers = vec!["ATU12345678", "ATU87654321"];
-        let invalid_vat_numbers = vec!["AT12345678", "ATU1234567", "ATU123456789", "ATU1234567A"];
-
+    fn assert_validations(valid_vat_numbers: Vec<&str>, invalid_vat_numbers: Vec<&str>) {
         for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
+            let valid_syntax = EUVat::validate_syntax(&EUVat, vat_number);
             assert_eq!(
                 valid_syntax,
-                true,
+                Ok(()),
                 "Expected valid VAT number, got invalid: {}",
                 vat_number
             );
         }
 
         for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
+            let valid_syntax = EUVat::validate_syntax(&EUVat, vat_number);
+            assert_eq!(valid_syntax, Err(ValidationError::InvalidSyntax));
         }
+    }
+
+    #[test]
+    fn test_at_vat() {
+        let valid_vat_numbers = vec!["ATU12345678", "ATU87654321"];
+        let invalid_vat_numbers = vec!["AT12345678", "ATU1234567", "ATU123456789", "ATU1234567A"];
+
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -84,25 +82,7 @@ mod tests {
             "BE012345678A",
         ];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -110,25 +90,7 @@ mod tests {
         let valid_vat_numbers = vec!["BG123456789", "BG1234567890"];
         let invalid_vat_numbers = vec!["BG12345678", "BG12345678901", "BG12345678A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -136,25 +98,7 @@ mod tests {
         let valid_vat_numbers = vec!["CY12345678A", "CY98765432Z"];
         let invalid_vat_numbers = vec!["CY12345678", "CY1234567A", "CY123456789A", "CY12345678AA"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -162,25 +106,7 @@ mod tests {
         let valid_vat_numbers = vec!["CZ12345678", "CZ123456789", "CZ1234567890"];
         let invalid_vat_numbers = vec!["CZ1234567", "CZ12345678901", "CZ12345678A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -188,25 +114,7 @@ mod tests {
         let valid_vat_numbers = vec!["DE123456789", "DE987654321"];
         let invalid_vat_numbers = vec!["DE12345678", "DE1234567890", "DE12345678A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -214,25 +122,7 @@ mod tests {
         let valid_vat_numbers = vec!["DK12345678"];
         let invalid_vat_numbers = vec!["DK1234567", "DK123456789", "DK1234567A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -240,25 +130,7 @@ mod tests {
         let valid_vat_numbers = vec!["EE101234567"];
         let invalid_vat_numbers = vec!["EE10123456", "EE1012345678", "EE10123456A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -266,25 +138,7 @@ mod tests {
         let valid_vat_numbers = vec!["EL123456789"];
         let invalid_vat_numbers = vec!["EL12345678", "EL1234567890", "EL12345678A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -292,25 +146,7 @@ mod tests {
         let valid_vat_numbers = vec!["ESX12345678", "ES12345678Z", "ESX1234567Z"];
         let invalid_vat_numbers = vec!["ES12345678", "ESX123456789", "ES12345678ZZ"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -318,25 +154,7 @@ mod tests {
         let valid_vat_numbers = vec!["FI12345678"];
         let invalid_vat_numbers = vec!["FI1234567", "FI123456789", "FI1234567A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -344,25 +162,7 @@ mod tests {
         let valid_vat_numbers = vec!["FR12345678901", "FRX1234567890"];
         let invalid_vat_numbers = vec!["FR1234567890", "FR123456789012", "FR1234567890A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -370,25 +170,7 @@ mod tests {
         let valid_vat_numbers = vec!["HR12345678901"];
         let invalid_vat_numbers = vec!["HR1234567890", "HR123456789012", "HR1234567890A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -396,25 +178,7 @@ mod tests {
         let valid_vat_numbers = vec!["HU12345678"];
         let invalid_vat_numbers = vec!["HU1234567", "HU123456789", "HU1234567A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -422,25 +186,7 @@ mod tests {
         let valid_vat_numbers = vec!["IE1234567A", "IE1A23456A", "IE1234567AA"];
         let invalid_vat_numbers = vec!["IE1234567", "IE12345678A", "IE1234567AAA"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -448,25 +194,7 @@ mod tests {
         let valid_vat_numbers = vec!["IT12345678901"];
         let invalid_vat_numbers = vec!["IT1234567890", "IT123456789012", "IT1234567890A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -474,25 +202,7 @@ mod tests {
         let valid_vat_numbers = vec!["LT999999919", "LT999999919"];
         let invalid_vat_numbers = vec!["LT12345678", "LT12345678901", "LT12345678A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -500,25 +210,7 @@ mod tests {
         let valid_vat_numbers = vec!["LU12345678"];
         let invalid_vat_numbers = vec!["LU1234567", "LU123456789", "LU1234567A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -526,25 +218,7 @@ mod tests {
         let valid_vat_numbers = vec!["LV12345678901"];
         let invalid_vat_numbers = vec!["LV1234567890", "LV123456789012", "LV1234567890A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -552,25 +226,7 @@ mod tests {
         let valid_vat_numbers = vec!["MT12345678"];
         let invalid_vat_numbers = vec!["MT1234567", "MT123456789", "MT1234567A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -578,25 +234,7 @@ mod tests {
         let valid_vat_numbers = vec!["NL123456789B01"];
         let invalid_vat_numbers = vec!["NL123456789B0", "NL123456789B012", "NL123456789B0A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -604,25 +242,7 @@ mod tests {
         let valid_vat_numbers = vec!["PL1234567890"];
         let invalid_vat_numbers = vec!["PL123456789", "PL12345678901", "PL123456789A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -630,25 +250,7 @@ mod tests {
         let valid_vat_numbers = vec!["PT123456789"];
         let invalid_vat_numbers = vec!["PT12345678", "PT1234567890", "PT12345678A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -656,25 +258,7 @@ mod tests {
         let valid_vat_numbers = vec!["RO99999999", "RO999999999"];
         let invalid_vat_numbers = vec!["RO12345678910", "RO12345678901", "RO12345678A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -682,25 +266,7 @@ mod tests {
         let valid_vat_numbers = vec!["SE123456789101"];
         let invalid_vat_numbers = vec!["SE12345678900", "SE123456789002", "SE12345678900A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -708,25 +274,7 @@ mod tests {
         let valid_vat_numbers = vec!["SI12345678"];
         let invalid_vat_numbers = vec!["SI1234567", "SI123456789", "SI1234567A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -734,25 +282,7 @@ mod tests {
         let valid_vat_numbers = vec!["SK1234567890"];
         let invalid_vat_numbers = vec!["SK123456789", "SK12345678901", "SK123456789A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
     #[test]
@@ -760,24 +290,6 @@ mod tests {
         let valid_vat_numbers = vec!["XI123456789", "XI987654321", "XIHA123", "XIGD123"];
         let invalid_vat_numbers = vec!["XI12345678", "XI1234567890", "XI12345678A"];
 
-        for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                true,
-                "Expected valid VAT number, got invalid: {}",
-                vat_number
-            );
-        }
-
-        for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::ensure_valid_syntax(&EUVat, vat_number);
-            assert_eq!(
-                valid_syntax,
-                false,
-                "Expected invalid VAT number, got valid: {}",
-                vat_number
-            );
-        }
+        assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ mod eu_vat;
 mod gb_vat;
 mod ch_vat;
 mod no_vat;
+mod syntax;

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+use regex::Regex;
+use crate::ch_vat::CHVat;
+use crate::eu_vat::EUVat;
+use crate::gb_vat::GBVat;
+use crate::no_vat::NOVat;
+use crate::tax_id::TaxIdType;
+
+lazy_static! {
+    pub static ref SYNTAX: HashMap<String, Regex> = {
+        let mut m = HashMap::new();
+
+        let types: Vec<Box<dyn TaxIdType>> = vec![
+            Box::new(GBVat),
+            Box::new(CHVat),
+            Box::new(NOVat),
+            Box::new(EUVat),
+        ];
+
+        for t in types {
+            let syntax_map = t.syntax_map();
+            for (code, pattern) in syntax_map {
+                m.insert(code.to_string(), pattern.clone());
+            }
+        }
+
+        m
+    };
+}


### PR DESCRIPTION
### Why?

Enable users to call syntax validation only (no verification with external database).

### What's changed?
- Added a TaxIdType trait method: `syntax_map(&self) -> &HashMap<String, Regex>` that returns a HashMap of regexes. Hash with 27 records for EUVat, single record hashes for NOVat, CHVat and GBVat.
- Renamed & refactored the TaxIdType trait method for validation:

```rust
// From:
ensure_valid_syntax(&self, value: &str) -> bool;

// To:
validate_syntax(&self, value: &str) -> Result<(), ValidationError>
```

- Added a global syntax map (merging all TaxIdTypes syntax maps)
- Added a `validate_syntax(&self, value: &str) -> Result<(), ValidationError>` method that runs against global syntax