### PR TITLE
feat: featurize the lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,17 @@ edition = "2021"
 lazy_static = "1.4.0"
 regex = "1.10.4"
 reqwest = { version = "0.12.4", features = ["blocking"] }
-roxmltree = "0.19.0"
+roxmltree = {  version = "0.19.0", optional = true }
 chrono = "0.4.38"
 serde_json = "1.0.116"
 thiserror = "1.0.60"
-toml = "0.8.12"
+toml = { version = "0.8.12", optional = true }
+
+
+[features]
+default = ["eu_vat"]
+eu_vat = ["roxmltree"]
+gb_vat = []
+ch_vat = ["roxmltree"]
+no_vat = ["toml"]
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,9 +15,6 @@ pub enum VerificationError {
     #[error("HTTP client error: {0}")]
     HttpError(#[from] reqwest::Error),
 
-    #[error("XML parsing error: {0}")]
-    XmlParsingError(#[from] roxmltree::Error),
-
     #[error("JSON parsing error: {0}")]
     JSONParsingError(#[source] serde_json::Error),
 
@@ -26,6 +23,9 @@ pub enum VerificationError {
 
     #[error("Unexpected status code: {0}")]
     UnexpectedStatusCode(u16),
+
+    #[error("XML parsing error: {0}")]
+    XmlParsingError(#[from] roxmltree::Error),
 }
 
 impl Debug for VerificationError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,7 @@ pub enum VerificationError {
     #[error("Unexpected status code: {0}")]
     UnexpectedStatusCode(u16),
 
+    #[cfg(any(feature = "eu_vat", feature = "ch_vat"))]
     #[error("XML parsing error: {0}")]
     XmlParsingError(#[from] roxmltree::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,12 @@ pub mod tax_id;
 mod errors;
 mod verification;
 mod syntax;
+
+#[cfg(feature = "eu_vat")]
 mod eu_vat;
+#[cfg(feature = "gb_vat")]
 mod gb_vat;
+#[cfg(feature = "ch_vat")]
 mod ch_vat;
+#[cfg(feature = "no_vat")]
 mod no_vat;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 mod tax_id;
 mod errors;
 mod verification;
+mod syntax;
 mod eu_vat;
 mod gb_vat;
 mod ch_vat;
 mod no_vat;
-mod syntax;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod tax_id;
+pub mod tax_id;
 mod errors;
 mod verification;
 mod syntax;

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2,9 +2,14 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use regex::Regex;
 use crate::tax_id::TaxIdType;
+
+#[cfg(feature = "ch_vat")]
 use crate::ch_vat::CHVat;
+#[cfg(feature = "eu_vat")]
 use crate::eu_vat::EUVat;
+#[cfg(feature = "gb_vat")]
 use crate::gb_vat::GBVat;
+#[cfg(feature = "no_vat")]
 use crate::no_vat::NOVat;
 
 lazy_static! {
@@ -12,9 +17,13 @@ lazy_static! {
         let mut m = HashMap::new();
 
         let types: Vec<Box<dyn TaxIdType>> = vec![
+            #[cfg(feature = "gb_vat")]
             Box::new(GBVat),
+            #[cfg(feature = "ch_vat")]
             Box::new(CHVat),
+            #[cfg(feature = "no_vat")]
             Box::new(NOVat),
+            #[cfg(feature = "eu_vat")]
             Box::new(EUVat),
         ];
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use lazy_static::lazy_static;
 use regex::Regex;
+use crate::tax_id::TaxIdType;
 use crate::ch_vat::CHVat;
 use crate::eu_vat::EUVat;
 use crate::gb_vat::GBVat;
 use crate::no_vat::NOVat;
-use crate::tax_id::TaxIdType;
 
 lazy_static! {
     pub static ref SYNTAX: HashMap<String, Regex> = {

--- a/src/tax_id.rs
+++ b/src/tax_id.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 use std::fmt;
 use regex::Regex;
+use crate::errors::{ValidationError, VerificationError};
+use crate::syntax::SYNTAX;
+use crate::verification::{Verification, Verifier};
 use crate::ch_vat::CHVat;
 use crate::eu_vat::EUVat;
 use crate::gb_vat::GBVat;
-use crate::errors::{ValidationError, VerificationError};
 use crate::eu_vat;
 use crate::no_vat::NOVat;
-use crate::syntax::SYNTAX;
-use crate::verification::{Verification, Verifier};
 
 pub trait TaxIdType {
     fn name(&self) -> &'static str;

--- a/src/tax_id.rs
+++ b/src/tax_id.rs
@@ -4,10 +4,16 @@ use regex::Regex;
 use crate::errors::{ValidationError, VerificationError};
 use crate::syntax::SYNTAX;
 use crate::verification::{Verification, Verifier};
+
+#[cfg(feature = "ch_vat")]
 use crate::ch_vat::CHVat;
+#[cfg(feature = "eu_vat")]
 use crate::eu_vat::EUVat;
+#[cfg(feature = "gb_vat")]
 use crate::gb_vat::GBVat;
+#[cfg(feature = "eu_vat")]
 use crate::eu_vat;
+#[cfg(feature = "no_vat")]
 use crate::no_vat::NOVat;
 
 pub trait TaxIdType {
@@ -66,9 +72,13 @@ impl TaxId {
         let local_value = &value[2..];
 
         let id_type: Box<dyn TaxIdType> = match tax_country_code {
+            #[cfg(feature = "gb_vat")]
             "GB" => Box::new(GBVat),
+            #[cfg(feature = "ch_vat")]
             "CH" => Box::new(CHVat),
+            #[cfg(feature = "no_vat")]
             "NO" => Box::new(NOVat),
+            #[cfg(feature = "eu_vat")]
             _ if eu_vat::COUNTRIES.contains(&tax_country_code) => Box::new(EUVat),
             _ => return Err(ValidationError::UnsupportedCountryCode(tax_country_code.to_string()))
         };


### PR DESCRIPTION
### Why?

Most likely, users only want to use the EU VAT functionality.

That's why features supporting validation and verification of other supported tax ids like GB VAT, CH VAT and NO VAT should be optional.

### What changed?
- Lib divided into four features: `["eu_vat", "gb_vat", "ch_vat", "no_vat"]`.
- Default set to `"eu_vat"`.
- The `toml` dependency is marked optional and is only used by `"no_vat"` for translations.
- The `roxmltree` dependency is marked optional and is used by `"eu_vat"` and `"ch_vat"`.