### PR TITLE
refactor: linting acronyms

### DIFF
--- a/src/ch_vat/mod.rs
+++ b/src/ch_vat/mod.rs
@@ -17,9 +17,9 @@ lazy_static! {
     };
 }
 
-pub struct CHVat;
+pub struct ChVat;
 
-impl TaxIdType for CHVat {
+impl TaxIdType for ChVat {
     fn name(&self) -> &'static str {
         "ch_vat"
     }
@@ -85,11 +85,11 @@ mod tests {
         ];
 
         for valid in valid_vat_numbers {
-            assert!(CHVat::validate_syntax(&CHVat, valid).is_ok());
+            assert!(ChVat::validate_syntax(&ChVat, valid).is_ok());
         }
 
         for invalid in invalid_vat_numbers {
-            assert!(CHVat::validate_syntax(&CHVat, invalid).is_err());
+            assert!(ChVat::validate_syntax(&ChVat, invalid).is_err());
         }
     }
 }

--- a/src/ch_vat/mod.rs
+++ b/src/ch_vat/mod.rs
@@ -28,7 +28,7 @@ impl TaxIdType for ChVat {
         &CH_VAT_PATTERN
     }
 
-    fn country_code_from(&self, tax_country_code: &str) -> String {
+    fn country_code_from_tax_country(&self, tax_country_code: &str) -> String {
         tax_country_code.to_string()
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,7 +16,7 @@ pub enum VerificationError {
     HttpError(#[from] reqwest::Error),
 
     #[error("JSON parsing error: {0}")]
-    JSONParsingError(#[source] serde_json::Error),
+    JsonParsingError(#[source] serde_json::Error),
 
     #[error("Unexpected response: {0}")]
     UnexpectedResponse(String),

--- a/src/eu_vat/mod.rs
+++ b/src/eu_vat/mod.rs
@@ -27,7 +27,7 @@ impl TaxIdType for EuVat {
         &EU_VAT_PATTERNS
     }
 
-    fn country_code_from(&self, tax_country_code: &str) -> String {
+    fn country_code_from_tax_country(&self, tax_country_code: &str) -> String {
         let country_code = match tax_country_code {
             "XI" => "GB",
             "EL" => "GR",

--- a/src/eu_vat/mod.rs
+++ b/src/eu_vat/mod.rs
@@ -8,7 +8,7 @@ use syntax::EU_VAT_PATTERNS;
 use crate::tax_id::TaxIdType;
 use crate::verification::{Verifier};
 
-pub struct EUVat;
+pub struct EuVat;
 
 lazy_static! {
     #[derive(Debug)]
@@ -18,7 +18,7 @@ lazy_static! {
     ];
 }
 
-impl TaxIdType for EUVat {
+impl TaxIdType for EuVat {
     fn name(&self) -> &'static str {
         "eu_vat"
     }
@@ -49,7 +49,7 @@ mod tests {
 
     fn assert_validations(valid_vat_numbers: Vec<&str>, invalid_vat_numbers: Vec<&str>) {
         for vat_number in valid_vat_numbers {
-            let valid_syntax = EUVat::validate_syntax(&EUVat, vat_number);
+            let valid_syntax = EuVat::validate_syntax(&EuVat, vat_number);
             assert_eq!(
                 valid_syntax,
                 Ok(()),
@@ -59,7 +59,7 @@ mod tests {
         }
 
         for vat_number in invalid_vat_numbers {
-            let valid_syntax = EUVat::validate_syntax(&EUVat, vat_number);
+            let valid_syntax = EuVat::validate_syntax(&EuVat, vat_number);
             assert_eq!(valid_syntax, Err(ValidationError::InvalidSyntax));
         }
     }

--- a/src/gb_vat/hmrc.rs
+++ b/src/gb_vat/hmrc.rs
@@ -31,7 +31,7 @@ impl Verifier for HMRC {
 
     fn parse_response(&self, response: VerificationResponse) -> Result<Verification, VerificationError> {
         let v: serde_json::Value = serde_json::from_str(response.body())
-            .map_err(VerificationError::JSONParsingError)?;
+            .map_err(VerificationError::JsonParsingError)?;
         let hash = v.as_object().unwrap();
         let fault = hash.get("code").and_then(|v| v.as_str());
 

--- a/src/gb_vat/mod.rs
+++ b/src/gb_vat/mod.rs
@@ -29,7 +29,7 @@ impl TaxIdType for GbVat {
         &GB_VAT_PATTERN
     }
 
-    fn country_code_from(&self, tax_country_code: &str) -> String {
+    fn country_code_from_tax_country(&self, tax_country_code: &str) -> String {
         tax_country_code.to_string()
     }
 

--- a/src/gb_vat/mod.rs
+++ b/src/gb_vat/mod.rs
@@ -18,9 +18,9 @@ lazy_static! {
 
 }
 
-pub struct GBVat;
+pub struct GbVat;
 
-impl TaxIdType for GBVat {
+impl TaxIdType for GbVat {
     fn name(&self) -> &'static str {
         "gb_vat"
     }
@@ -40,7 +40,7 @@ impl TaxIdType for GBVat {
 
 #[cfg(test)]
 mod tests {
-    use crate::gb_vat::GBVat;
+    use crate::gb_vat::GbVat;
     use crate::tax_id::TaxIdType;
 
     #[test]
@@ -60,11 +60,11 @@ mod tests {
         ];
 
         for valid in valid_vat_numbers {
-            assert!(GBVat::validate_syntax(&GBVat, valid).is_ok());
+            assert!(GbVat::validate_syntax(&GBVat, valid).is_ok());
         }
 
         for invalid in invalid_vat_numbers {
-            assert!(GBVat::validate_syntax(&GBVat, invalid).is_err());
+            assert!(GbVat::validate_syntax(&GBVat, invalid).is_err());
         }
 
     }

--- a/src/no_vat/brreg.rs
+++ b/src/no_vat/brreg.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::verification::{Verifier, Verification, VerificationStatus, VerificationResponse};
 use crate::tax_id::TaxId;
 use crate::errors::VerificationError;
-use crate::no_vat::NOVat;
+use crate::no_vat::NoVat;
 use crate::no_vat::translator::translate_keys;
 
 // INFO(2024-05-08 mollemoll):
@@ -57,7 +57,7 @@ impl Verifier for BRReg {
     fn make_request(&self, tax_id: &TaxId) -> Result<VerificationResponse, VerificationError> {
         let client = reqwest::blocking::Client::new();
         let res = client
-            .get(format!("{}/{}", BASE_URI, NOVat::extract_org_number(&NOVat, tax_id)))
+            .get(format!("{}/{}", BASE_URI, NoVat::extract_org_number(&NOVat, tax_id)))
             .headers(HEADERS.clone())
             .send()
             .map_err(VerificationError::HttpError)?;

--- a/src/no_vat/brreg.rs
+++ b/src/no_vat/brreg.rs
@@ -79,7 +79,7 @@ impl Verifier for BRReg {
             ),
             200 | 500 => {
                 let mut v: Value = serde_json::from_str(response.body())
-                    .map_err(VerificationError::JSONParsingError)?;
+                    .map_err(VerificationError::JsonParsingError)?;
                 translate_keys(&mut v);
                 let hash = v.as_object().unwrap();
 

--- a/src/no_vat/mod.rs
+++ b/src/no_vat/mod.rs
@@ -31,7 +31,7 @@ impl TaxIdType for NoVat {
         &NO_VAT_PATTERN
     }
 
-    fn country_code_from(&self, tax_country_code: &str) -> String {
+    fn country_code_from_tax_country(&self, tax_country_code: &str) -> String {
         tax_country_code.to_string()
     }
 

--- a/src/no_vat/mod.rs
+++ b/src/no_vat/mod.rs
@@ -15,15 +15,15 @@ lazy_static! {
     };
 }
 
-pub struct NOVat;
+pub struct NoVat;
 
-impl NOVat {
+impl NoVat {
     pub fn extract_org_number(&self, tax_id: &TaxId) -> String {
         tax_id.local_value().replace("MVA", "")
     }
 }
 
-impl TaxIdType for NOVat {
+impl TaxIdType for NoVat {
     fn name(&self) -> &'static str {
         "no_vat"
     }
@@ -48,7 +48,7 @@ mod tests {
     fn test_extract_org_number() {
         let tax_id = TaxId::new("NO123456789MVA").unwrap();
 
-        assert_eq!(NOVat::extract_org_number(&NOVat, &tax_id), "123456789");
+        assert_eq!(NoVat::extract_org_number(&NoVat, &tax_id), "123456789");
     }
 
     #[test]
@@ -68,11 +68,11 @@ mod tests {
         ];
 
         for valid in valid_vat_numbers {
-            assert!(NOVat::validate_syntax(&NOVat, valid).is_ok());
+            assert!(NoVat::validate_syntax(&NoVat, valid).is_ok());
         }
 
         for invalid in invalid_vat_numbers {
-            assert!(NOVat::validate_syntax(&NOVat, invalid).is_err());
+            assert!(NoVat::validate_syntax(&NoVat, invalid).is_err());
         }
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -4,13 +4,13 @@ use regex::Regex;
 use crate::tax_id::TaxIdType;
 
 #[cfg(feature = "ch_vat")]
-use crate::ch_vat::CHVat;
+use crate::ch_vat::ChVat;
 #[cfg(feature = "eu_vat")]
-use crate::eu_vat::EUVat;
+use crate::eu_vat::EuVat;
 #[cfg(feature = "gb_vat")]
-use crate::gb_vat::GBVat;
+use crate::gb_vat::GbVat;
 #[cfg(feature = "no_vat")]
-use crate::no_vat::NOVat;
+use crate::no_vat::NoVat;
 
 lazy_static! {
     pub static ref SYNTAX: HashMap<String, Regex> = {
@@ -18,13 +18,13 @@ lazy_static! {
 
         let types: Vec<Box<dyn TaxIdType>> = vec![
             #[cfg(feature = "gb_vat")]
-            Box::new(GBVat),
+            Box::new(GbVat),
             #[cfg(feature = "ch_vat")]
-            Box::new(CHVat),
+            Box::new(ChVat),
             #[cfg(feature = "no_vat")]
-            Box::new(NOVat),
+            Box::new(NoVat),
             #[cfg(feature = "eu_vat")]
-            Box::new(EUVat),
+            Box::new(EuVat),
         ];
 
         for t in types {

--- a/src/tax_id.rs
+++ b/src/tax_id.rs
@@ -31,7 +31,7 @@ pub trait TaxIdType {
             Err(ValidationError::InvalidSyntax)
         }
     }
-    fn country_code_from(&self, tax_country_code: &str) -> String;
+    fn country_code_from_tax_country(&self, tax_country_code: &str) -> String;
     fn verifier(&self) -> Box<dyn Verifier>;
     fn verify(&self, tax_id: &TaxId) -> Result<Verification, VerificationError> {
         self.verifier().verify(tax_id)
@@ -86,7 +86,7 @@ impl TaxId {
         id_type.validate_syntax(value)?;
 
         Ok(TaxId {
-            country_code: id_type.country_code_from(tax_country_code),
+            country_code: id_type.country_code_from_tax_country(tax_country_code),
             value: value.to_string(),
             tax_country_code: tax_country_code.to_string(),
             local_value: local_value.to_string(),

--- a/src/tax_id.rs
+++ b/src/tax_id.rs
@@ -6,15 +6,15 @@ use crate::syntax::SYNTAX;
 use crate::verification::{Verification, Verifier};
 
 #[cfg(feature = "ch_vat")]
-use crate::ch_vat::CHVat;
+use crate::ch_vat::ChVat;
 #[cfg(feature = "eu_vat")]
-use crate::eu_vat::EUVat;
+use crate::eu_vat::EuVat;
 #[cfg(feature = "gb_vat")]
-use crate::gb_vat::GBVat;
+use crate::gb_vat::GbVat;
 #[cfg(feature = "eu_vat")]
 use crate::eu_vat;
 #[cfg(feature = "no_vat")]
-use crate::no_vat::NOVat;
+use crate::no_vat::NoVat;
 
 pub trait TaxIdType {
     fn name(&self) -> &'static str;
@@ -73,13 +73,13 @@ impl TaxId {
 
         let id_type: Box<dyn TaxIdType> = match tax_country_code {
             #[cfg(feature = "gb_vat")]
-            "GB" => Box::new(GBVat),
+            "GB" => Box::new(GbVat),
             #[cfg(feature = "ch_vat")]
-            "CH" => Box::new(CHVat),
+            "CH" => Box::new(ChVat),
             #[cfg(feature = "no_vat")]
-            "NO" => Box::new(NOVat),
+            "NO" => Box::new(NoVat),
             #[cfg(feature = "eu_vat")]
-            _ if eu_vat::COUNTRIES.contains(&tax_country_code) => Box::new(EUVat),
+            _ if eu_vat::COUNTRIES.contains(&tax_country_code) => Box::new(EuVat),
             _ => return Err(ValidationError::UnsupportedCountryCode(tax_country_code.to_string()))
         };
 


### PR DESCRIPTION
### Why?

Wasn't following standards according to the [Rust API checklist](https://rust-lang.github.io/api-guidelines/checklist.html).

### What's changed?

- `XXVat` renamed to `XxVat`
- `JSONParsingError` renamed to `JsonParsingError`
- Renamed method `TaxId#country_code_from(tax_country)` to `TaxId#country_code_from_tax_country(tax_country)`