### PR TITLE
fix: debug for all public types

### DIFF
--- a/src/ch_vat/bfs.rs
+++ b/src/ch_vat/bfs.rs
@@ -27,6 +27,7 @@ static ENVELOPE: &'static str = "
 ";
 
 lazy_static! {
+    #[derive(Debug)]
     pub static ref HEADERS: HeaderMap = {
         let mut headers = HeaderMap::new();
         headers.insert(ACCEPT, HeaderValue::from_static("text/xml;charset=UTF-8"));
@@ -39,6 +40,7 @@ lazy_static! {
     };
 }
 
+#[derive(Debug)]
 pub struct BFS;
 
 impl BFS {

--- a/src/ch_vat/mod.rs
+++ b/src/ch_vat/mod.rs
@@ -7,6 +7,7 @@ use crate::tax_id::TaxIdType;
 use crate::verification::Verifier;
 
 lazy_static! {
+    #[derive(Debug)]
     pub static ref CH_VAT_PATTERN: HashMap<String, Regex> = {
         let mut m = HashMap::new();
         m.insert(
@@ -17,6 +18,7 @@ lazy_static! {
     };
 }
 
+#[derive(Debug)]
 pub struct ChVat;
 
 impl TaxIdType for ChVat {

--- a/src/eu_vat/mod.rs
+++ b/src/eu_vat/mod.rs
@@ -8,6 +8,7 @@ use syntax::EU_VAT_PATTERNS;
 use crate::tax_id::TaxIdType;
 use crate::verification::{Verifier};
 
+#[derive(Debug)]
 pub struct EuVat;
 
 lazy_static! {

--- a/src/eu_vat/syntax.rs
+++ b/src/eu_vat/syntax.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use regex::Regex;
 
 lazy_static! {
+    #[derive(Debug)]
     pub static ref EU_VAT_PATTERNS: HashMap<String, Regex> = {
         let mut m = HashMap::new();
         m.insert("AT".to_string(), Regex::new(r"^ATU[0-9]{8}$").unwrap());

--- a/src/eu_vat/vies.rs
+++ b/src/eu_vat/vies.rs
@@ -22,6 +22,7 @@ static ENVELOPE: &'static str = "
 </soapenv:Envelope>
 ";
 
+#[derive(Debug)]
 pub struct VIES;
 
 impl VIES {

--- a/src/gb_vat/hmrc.rs
+++ b/src/gb_vat/hmrc.rs
@@ -10,6 +10,7 @@ use crate::verification::{Verification, VerificationResponse, VerificationStatus
 
 static BASE_URI: &'static str = "https://api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup";
 
+#[derive(Debug)]
 pub struct HMRC;
 
 impl Verifier for HMRC {

--- a/src/gb_vat/mod.rs
+++ b/src/gb_vat/mod.rs
@@ -7,6 +7,7 @@ use crate::tax_id::TaxIdType;
 use crate::verification::Verifier;
 
 lazy_static! {
+    #[derive(Debug)]
     pub static ref GB_VAT_PATTERN: HashMap<String, Regex> = {
         let mut m = HashMap::new();
         m.insert(
@@ -18,6 +19,7 @@ lazy_static! {
 
 }
 
+#[derive(Debug)]
 pub struct GbVat;
 
 impl TaxIdType for GbVat {

--- a/src/no_vat/brreg.rs
+++ b/src/no_vat/brreg.rs
@@ -16,12 +16,14 @@ use crate::no_vat::translator::translate_keys;
 static BASE_URI: &'static str = "https://data.brreg.no/enhetsregisteret/api/enheter";
 
 lazy_static! {
+    #[derive(Debug)]
     pub static ref HEADERS: HeaderMap = {
         let mut headers = HeaderMap::new();
         headers.insert(ACCEPT, HeaderValue::from_static("application/vnd.brreg.enhetsregisteret.enhet.v2+json"));
         headers
     };
 
+    #[derive(Debug)]
     pub static ref REQUIREMENTS_TO_BE_VALID : HashMap<&'static str, bool> = {
         let mut map = HashMap::new();
         map.insert("registeredInVatRegister", true); // Registered for VAT
@@ -32,6 +34,7 @@ lazy_static! {
     };
 }
 
+#[derive(Debug)]
 pub struct BRReg;
 
 impl BRReg {

--- a/src/no_vat/mod.rs
+++ b/src/no_vat/mod.rs
@@ -8,6 +8,7 @@ use crate::tax_id::{TaxId, TaxIdType};
 use crate::verification::Verifier;
 
 lazy_static! {
+    #[derive(Debug)]
     pub static ref NO_VAT_PATTERN: HashMap<String, Regex> = {
         let mut m = HashMap::new();
         m.insert("NO".to_string(), Regex::new(r"^NO[0-9]{9}(MVA)?$").unwrap());
@@ -15,6 +16,7 @@ lazy_static! {
     };
 }
 
+#[derive(Debug)]
 pub struct NoVat;
 
 impl NoVat {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -13,6 +13,7 @@ use crate::gb_vat::GbVat;
 use crate::no_vat::NoVat;
 
 lazy_static! {
+    #[derive(Debug)]
     pub static ref SYNTAX: HashMap<String, Regex> = {
         let mut m = HashMap::new();
 

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -2,6 +2,7 @@ use chrono::prelude::*;
 use crate::tax_id::TaxId;
 use crate::errors::VerificationError;
 
+#[derive(Debug, PartialEq)]
 pub struct VerificationResponse {
     status: u16,
     body: String,
@@ -26,7 +27,7 @@ pub enum VerificationStatus {
     Unavailable,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Verification {
     performed_at: DateTime<Local>,
     status: VerificationStatus,


### PR DESCRIPTION
### Why?

Wasn't following standards according to [Rust API checklist](https://rust-lang.github.io/api-guidelines/checklist.html)

### What changed?

- Added `Debug` to all public types
- Added `PartialEq` to `Verification` and `VerificationResponse`