### PR TITLE
refactor: naming acronyms

### DIFF
--- a/src/ch_vat/bfs.rs
+++ b/src/ch_vat/bfs.rs
@@ -10,7 +10,7 @@ use crate::TaxId;
 // INFO(2024-05-07 mollemoll):
 // https://www.bfs.admin.ch/bfs/en/home/registers/enterprise-register/enterprise-identification/uid-register/uid-interfaces.html#-125185306
 // https://www.bfs.admin.ch/bfs/fr/home/registres/registre-entreprises/numero-identification-entreprises/registre-ide/interfaces-ide.assetdetail.11007266.html
-// BFS Accepted format: 'CHE123456789' or 'CHE-123.456.789' with optional space and
+// Bfs Accepted format: 'CHE123456789' or 'CHE-123.456.789' with optional space and
 // MWST/TVA/IVA extension: 'CHE123456789 MWST' or 'CHE-123.456.789 MWST'
 
 static URI: &'static str = "https://www.uid-wse-a.admin.ch/V5.0/PublicServices.svc";
@@ -41,9 +41,9 @@ lazy_static! {
 }
 
 #[derive(Debug)]
-pub struct BFS;
+pub struct Bfs;
 
-impl BFS {
+impl Bfs {
     fn xml_to_hash(xml: &roxmltree::Document) -> HashMap<String, Option<String>> {
         let mut hash = HashMap::new();
         let tags_to_exclude = [
@@ -70,7 +70,7 @@ impl BFS {
     }
 }
 
-impl Verifier for BFS {
+impl Verifier for Bfs {
     fn make_request(&self, tax_id: &TaxId) -> Result<VerificationResponse, VerificationError> {
         let client = reqwest::blocking::Client::new();
         let body = ENVELOPE
@@ -92,7 +92,7 @@ impl Verifier for BFS {
 
     fn parse_response(&self, response: VerificationResponse) -> Result<Verification, VerificationError> {
         let doc = roxmltree::Document::parse(response.body()).map_err(VerificationError::XmlParsingError)?;
-        let hash = BFS::xml_to_hash(&doc);
+        let hash = Bfs::xml_to_hash(&doc);
         let fault_string = hash.get("faultstring")
             .and_then(|x| x.as_deref());
 
@@ -134,7 +134,7 @@ mod tests {
             </s:Envelope>
         "#;
         let doc = roxmltree::Document::parse(xml).unwrap();
-        let hash = BFS::xml_to_hash(&doc);
+        let hash = Bfs::xml_to_hash(&doc);
 
         assert_eq!(hash.get("ValidateVatNumberResult"), Some(&Some("true".to_string())));
     }
@@ -154,7 +154,7 @@ mod tests {
             "#.to_string()
         );
 
-        let verifier = BFS;
+        let verifier = Bfs;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Verified);
@@ -178,7 +178,7 @@ mod tests {
             "#.to_string()
         );
 
-        let verifier = BFS;
+        let verifier = Bfs;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Unverified);
@@ -210,7 +210,7 @@ mod tests {
             "#.to_string()
         );
 
-        let verifier = BFS;
+        let verifier = Bfs;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Unavailable);
@@ -239,7 +239,7 @@ mod tests {
             "#.to_string()
         );
 
-        let verifier = BFS;
+        let verifier = Bfs;
         let verification = verifier.parse_response(response);
 
         match verification {
@@ -265,7 +265,7 @@ mod tests {
             "#.to_string()
         );
 
-        let verifier = BFS;
+        let verifier = Bfs;
         let verification = verifier.parse_response(response);
 
         match verification {
@@ -291,7 +291,7 @@ mod tests {
             "#.to_string()
         );
 
-        let verifier = BFS;
+        let verifier = Bfs;
         let verification = verifier.parse_response(response);
 
         match verification {

--- a/src/ch_vat/mod.rs
+++ b/src/ch_vat/mod.rs
@@ -35,7 +35,7 @@ impl TaxIdType for ChVat {
     }
 
     fn verifier(&self) -> Box<dyn Verifier> {
-        Box::new(bfs::BFS)
+        Box::new(bfs::Bfs)
     }
 }
 

--- a/src/eu_vat/mod.rs
+++ b/src/eu_vat/mod.rs
@@ -39,7 +39,7 @@ impl TaxIdType for EuVat {
     }
 
     fn verifier(&self) -> Box<dyn Verifier> {
-        Box::new(vies::VIES)
+        Box::new(vies::Vies)
     }
 }
 

--- a/src/eu_vat/vies.rs
+++ b/src/eu_vat/vies.rs
@@ -6,7 +6,7 @@ use crate::errors::VerificationError;
 use crate::TaxId;
 
 // INFO(2024-05-08 mollemoll):
-// Data from VIES
+// Data from Vies
 // https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl
 
 static URI: &'static str = "http://ec.europa.eu/taxation_customs/vies/services/checkVatService";
@@ -23,9 +23,9 @@ static ENVELOPE: &'static str = "
 ";
 
 #[derive(Debug)]
-pub struct VIES;
+pub struct Vies;
 
-impl VIES {
+impl Vies {
     fn xml_to_hash(xml: &roxmltree::Document) -> HashMap<String, Option<String>> {
         let mut hash = HashMap::new();
         let tags_to_exclude = ["Body", "Envelope", "Fault"];
@@ -50,7 +50,7 @@ impl VIES {
     }
 }
 
-impl Verifier for VIES {
+impl Verifier for Vies {
     fn make_request(&self, tax_id: &TaxId) -> Result<VerificationResponse, VerificationError> {
         let client = reqwest::blocking::Client::new();
         let body = ENVELOPE
@@ -73,7 +73,7 @@ impl Verifier for VIES {
 
     fn parse_response(&self, response: VerificationResponse) -> Result<Verification, VerificationError> {
         let doc = roxmltree::Document::parse(response.body()).map_err(VerificationError::XmlParsingError)?;
-        let hash = VIES::xml_to_hash(&doc);
+        let hash = Vies::xml_to_hash(&doc);
         let fault_string = hash.get("faultstring")
             .and_then(|x| x.as_deref());
 
@@ -131,7 +131,7 @@ mod tests {
             </soapenv:Envelope>
         "#;
         let doc = roxmltree::Document::parse(xml).unwrap();
-        let hash = VIES::xml_to_hash(&doc);
+        let hash = Vies::xml_to_hash(&doc);
 
         assert_eq!(hash.get("countryCode"), Some(&Some("SE".to_string())));
         assert_eq!(hash.get("vatNumber"), Some(&Some("123456789101".to_string())));
@@ -161,7 +161,7 @@ mod tests {
                     </soapenv:Envelope>
                 "#.to_string()
         );
-        let verifier = VIES;
+        let verifier = Vies;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Verified);
@@ -187,7 +187,7 @@ mod tests {
                 </soapenv:Envelope>
             "#.to_string()
         );
-        let verifier = VIES;
+        let verifier = Vies;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Unverified);
@@ -209,7 +209,7 @@ mod tests {
                 </env:Envelope>
             "#.to_string()
         );
-        let verifier = VIES;
+        let verifier = Vies;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Unavailable);
@@ -234,7 +234,7 @@ mod tests {
                 </soapenv:Envelope>
             "#.to_string()
         );
-        let verifier = VIES;
+        let verifier = Vies;
         let verification = verifier.parse_response(response);
 
         match verification {
@@ -260,7 +260,7 @@ mod tests {
                 </soapenv:Envelope>
             "#.to_string()
         );
-        let verifier = VIES;
+        let verifier = Vies;
         let verification = verifier.parse_response(response);
 
         match verification {

--- a/src/gb_vat/hmrc.rs
+++ b/src/gb_vat/hmrc.rs
@@ -11,9 +11,9 @@ use crate::verification::{Verification, VerificationResponse, VerificationStatus
 static BASE_URI: &'static str = "https://api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup";
 
 #[derive(Debug)]
-pub struct HMRC;
+pub struct Hmrc;
 
-impl Verifier for HMRC {
+impl Verifier for Hmrc {
     fn make_request(&self, tax_id: &TaxId) -> Result<VerificationResponse, VerificationError> {
         let client = reqwest::blocking::Client::new();
         let res = client
@@ -86,7 +86,7 @@ mod tests {
             }"#.to_string()
         );
 
-        let verifier = HMRC;
+        let verifier = Hmrc;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Verified);
@@ -114,7 +114,7 @@ mod tests {
             }"#.to_string()
         );
 
-        let verifier = HMRC;
+        let verifier = Hmrc;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Unverified);
@@ -133,7 +133,7 @@ mod tests {
             }"#.to_string()
         );
 
-        let verifier = HMRC;
+        let verifier = Hmrc;
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &VerificationStatus::Unavailable);

--- a/src/gb_vat/mod.rs
+++ b/src/gb_vat/mod.rs
@@ -36,7 +36,7 @@ impl TaxIdType for GbVat {
     }
 
     fn verifier(&self) -> Box<dyn Verifier> {
-        Box::new(hmrc::HMRC)
+        Box::new(hmrc::Hmrc)
     }
 }
 

--- a/src/no_vat/brreg.rs
+++ b/src/no_vat/brreg.rs
@@ -35,9 +35,9 @@ lazy_static! {
 }
 
 #[derive(Debug)]
-pub struct BRReg;
+pub struct BrReg;
 
-impl BRReg {
+impl BrReg {
     fn qualify(&self, hash: &serde_json::Map<String, serde_json::Value>) -> VerificationStatus {
         let mut valid = true;
         for (key, value) in REQUIREMENTS_TO_BE_VALID.iter() {
@@ -56,7 +56,7 @@ impl BRReg {
     }
 }
 
-impl Verifier for BRReg {
+impl Verifier for BrReg {
     fn make_request(&self, tax_id: &TaxId) -> Result<VerificationResponse, VerificationError> {
         let client = reqwest::blocking::Client::new();
         let res = client
@@ -131,7 +131,7 @@ mod tests {
             }"#.to_string()
         );
 
-        let verifier = BRReg;
+        let verifier = BrReg;
         let verification = verifier.parse_response(response).unwrap();
         assert_eq!(verification.status(), &VerificationStatus::Verified);
         assert_eq!(verification.data(), &json!({
@@ -162,7 +162,7 @@ mod tests {
             r#"{}"#.to_string()
         );
 
-        let verifier = BRReg;
+        let verifier = BrReg;
         let verification = verifier.parse_response(response).unwrap();
         assert_eq!(verification.status(), &VerificationStatus::Unverified);
         assert_eq!(verification.data(), &json!({}));
@@ -182,7 +182,7 @@ mod tests {
             }"#.to_string()
         );
 
-        let verifier = BRReg;
+        let verifier = BrReg;
         let verification = verifier.parse_response(response).unwrap();
         assert_eq!(verification.status(), &VerificationStatus::Unverified);
         assert_eq!(verification.data(), &json!({
@@ -210,7 +210,7 @@ mod tests {
             "#.to_string()
         );
 
-        let verifier = BRReg;
+        let verifier = BrReg;
         let verification = verifier.parse_response(response).unwrap();
         assert_eq!(verification.status(), &VerificationStatus::Unverified);
         assert_eq!(verification.data(), &json!({}));
@@ -232,7 +232,7 @@ mod tests {
             "#.to_string()
         );
 
-        let verifier = BRReg;
+        let verifier = BrReg;
         let verification = verifier.parse_response(response).unwrap();
         assert_eq!(verification.status(), &VerificationStatus::Unavailable);
         assert_eq!(verification.data(), &json!({
@@ -252,7 +252,7 @@ mod tests {
             "".to_string()
         );
 
-        let verifier = BRReg;
+        let verifier = BrReg;
         let verification = verifier.parse_response(response);
         assert_eq!(verification.is_err(), true);
         match verification {

--- a/src/no_vat/mod.rs
+++ b/src/no_vat/mod.rs
@@ -38,7 +38,7 @@ impl TaxIdType for NoVat {
     }
 
     fn verifier(&self) -> Box<dyn Verifier> {
-        Box::new(brreg::BRReg)
+        Box::new(brreg::BrReg)
     }
 }
 


### PR DESCRIPTION
### Why?

Discovered some leftovers when naming acronyms verifiers. Let's align with Rust style guidelines.

### What changes?
- BFS -> Bfs
- VIES -> Vies
- HMRC -> Hmrc
- BRReg -> BrReg