### PR TITLE
feat: extend unavailable status with a reason

### DIFF
--- a/src/gb_vat/hmrc.rs
+++ b/src/gb_vat/hmrc.rs
@@ -6,7 +6,7 @@ use crate::verification::{Verification, VerificationResponse, VerificationStatus
 // INFO(2024-05-08 mollemoll):
 // Data from HMRC
 // https://www.tax.service.gov.uk/check-vat-number/enter-vat-details
-// https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/vat-api/1.0
+// https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/vat-registered-companies-api/1.0/oas/page
 
 static BASE_URI: &'static str = "https://api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::fmt;
 use regex::Regex;
 use syntax::SYNTAX;
 use verification::{Verifier};
-pub use verification::{Verification, VerificationStatus};
+pub use verification::{Verification, VerificationStatus, UnavailableReason};
 pub use errors::{ValidationError, VerificationError};
 
 

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -20,11 +20,19 @@ impl VerificationResponse {
     pub fn body(&self) -> &str { &self.body }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum VerificationStatus {
     Verified,
     Unverified,
-    Unavailable,
+    Unavailable(UnavailableReason),
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum UnavailableReason {
+    ServiceUnavailable,
+    Timeout,
+    Block,
+    RateLimit,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
### Why?

Users will be interested in why a verification came back as unavailable. For example, if the user has been rate-limited they would benefit from having that information to adapt.

### What changed?

- `VerificationStatus::Unavailable` -> `VerificationStatus::Unavailable(UnavailableReason)`
- New type `UnavailableReason` which currently can be one of:
   - `ServiceUnavailable`
   - `Timeout`
   - `Block`
   - `RateLimit`
 - All verifiers have been adapted to this 