### PR TITLE
refactor: put fault codes in constants

### DIFF
--- a/src/ch_vat/bfs.rs
+++ b/src/ch_vat/bfs.rs
@@ -26,6 +26,9 @@ static ENVELOPE: &'static str = "
     </soapenv:Envelope>
 ";
 
+const DATA_VALIDATION_FAILED: &str = "Data_validation_failed";
+const REQUEST_LIMIT_EXCEEDED: &str = "Request_limit_exceeded";
+
 lazy_static! {
     #[derive(Debug)]
     pub static ref HEADERS: HeaderMap = {
@@ -97,8 +100,8 @@ impl Verifier for Bfs {
             .and_then(|x| x.as_deref());
 
         let status = match fault_string {
-            Some("Data_validation_failed") => Unverified,
-            Some("Request_limit_exceeded") => Unavailable(RateLimit),
+            Some(DATA_VALIDATION_FAILED) => Unverified,
+            Some(REQUEST_LIMIT_EXCEEDED) => Unavailable(RateLimit),
             Some(_) => return Err(VerificationError::UnexpectedResponse(
                 format!("Unexpected faultstring: {}", fault_string.unwrap().to_string())
             )),
@@ -215,11 +218,11 @@ mod tests {
 
         assert_eq!(verification.status(), &Unavailable(RateLimit));
         assert_eq!(verification.data(), &json!({
-            "error": "Request_limit_exceeded",
+            "error": REQUEST_LIMIT_EXCEEDED,
             "errorDetail": "Maximum number of 20 requests per 1 minute(s) exceeded",
             "operation": "ValidateVatNumber",
             "faultcode": "s:Client",
-            "faultstring": "Request_limit_exceeded"
+            "faultstring": REQUEST_LIMIT_EXCEEDED
         }));
     }
 

--- a/src/eu_vat/vies.rs
+++ b/src/eu_vat/vies.rs
@@ -26,19 +26,31 @@ static ENVELOPE: &'static str = "
 </soapenv:Envelope>
 ";
 
+// Vies FAULT codes
+const SERVICE_UNAVAILABLE: &str = "SERVICE_UNAVAILABLE";
+const MS_UNAVAILABLE: &str = "MS_UNAVAILABLE";
+// const INVALID_REQUESTER_INFO: &str = "INVALID_REQUESTER_INFO";
+const TIMEOUT: &str = "TIMEOUT";
+const VAT_BLOCKED: &str = "VAT_BLOCKED";
+const IP_BLOCKED: &str = "IP_BLOCKED";
+const GLOBAL_MAX_CONCURRENT_REQ: &str = "GLOBAL_MAX_CONCURRENT_REQ";
+const GLOBAL_MAX_CONCURRENT_REQ_TIME: &str = "GLOBAL_MAX_CONCURRENT_REQ_TIME";
+const MS_MAX_CONCURRENT_REQ: &str = "MS_MAX_CONCURRENT_REQ";
+const MS_MAX_CONCURRENT_REQ_TIME: &str = "MS_MAX_CONCURRENT_REQ_TIME";
+
 lazy_static! {
     pub static ref FAULT_MAP: HashMap<&'static str, UnavailableReason> = {
         let mut m = HashMap::new();
-        m.insert("SERVICE_UNAVAILABLE", ServiceUnavailable);
-        m.insert("MS_UNAVAILABLE", ServiceUnavailable);
+        m.insert(SERVICE_UNAVAILABLE, ServiceUnavailable);
+        m.insert(MS_UNAVAILABLE, ServiceUnavailable);
         // Not implemented: 'INVALID_REQUESTER_INFO'
-        m.insert("TIMEOUT", Timeout);
-        m.insert("VAT_BLOCKED", Block);
-        m.insert("IP_BLOCKED", Block);
-        m.insert("GLOBAL_MAX_CONCURRENT_REQ", RateLimit);
-        m.insert("GLOBAL_MAX_CONCURRENT_REQ_TIME", RateLimit);
-        m.insert("MS_MAX_CONCURRENT_REQ", RateLimit);
-        m.insert("MS_MAX_CONCURRENT_REQ_TIME", RateLimit);
+        m.insert(TIMEOUT, Timeout);
+        m.insert(VAT_BLOCKED, Block);
+        m.insert(IP_BLOCKED, Block);
+        m.insert(GLOBAL_MAX_CONCURRENT_REQ, RateLimit);
+        m.insert(GLOBAL_MAX_CONCURRENT_REQ_TIME, RateLimit);
+        m.insert(MS_MAX_CONCURRENT_REQ, RateLimit);
+        m.insert(MS_MAX_CONCURRENT_REQ_TIME, RateLimit);
         m
     };
 }
@@ -245,7 +257,7 @@ mod tests {
         assert_eq!(verification.status(), &VerificationStatus::Unavailable(UnavailableReason::RateLimit));
         assert_eq!(verification.data(), &json!({
             "faultcode": "env:Server",
-            "faultstring": "MS_MAX_CONCURRENT_REQ"
+            "faultstring": MS_MAX_CONCURRENT_REQ
         }));
     }
 

--- a/src/gb_vat/hmrc.rs
+++ b/src/gb_vat/hmrc.rs
@@ -10,6 +10,9 @@ use crate::verification::UnavailableReason::ServiceUnavailable;
 // https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/vat-registered-companies-api/1.0/oas/page
 
 static BASE_URI: &'static str = "https://api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup";
+const NOT_FOUND: &str = "NOT_FOUND";
+const SERVER_ERROR: &str = "SERVER_ERROR";
+
 
 #[derive(Debug)]
 pub struct Hmrc;
@@ -44,7 +47,7 @@ impl Verifier for Hmrc {
                     json!(hash.get("target"))
                 )
             },
-            Some(fault_code) if fault_code == "NOT_FOUND" => {
+            Some(fault_code) if fault_code == NOT_FOUND => {
                 Verification::new(
                     Unverified,
                     json!(hash)
@@ -138,6 +141,6 @@ mod tests {
         let verification = verifier.parse_response(response).unwrap();
 
         assert_eq!(verification.status(), &Unavailable(ServiceUnavailable));
-        assert_eq!(verification.data().get("code").unwrap(), "SERVER_ERROR");
+        assert_eq!(verification.data().get("code").unwrap(), SERVER_ERROR);
     }
 }


### PR DESCRIPTION
### Why?

Lets put the verifier fault codes in constants.

### What changed?
- Fault codes put in constants
- Update test to assert these constants
- Update the Vies FAULT_MAP with these constants