### PR TITLE
fix: feature tests

### DIFF
--- a/src/ch_vat/bfs.rs
+++ b/src/ch_vat/bfs.rs
@@ -125,6 +125,7 @@ impl Verifier for Bfs {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "ch_vat")]
     #[test]
     fn test_bfs_xml_to_hash() {
         let xml = r#"
@@ -142,6 +143,7 @@ mod tests {
         assert_eq!(hash.get("ValidateVatNumberResult"), Some(&Some("true".to_string())));
     }
 
+    #[cfg(feature = "ch_vat")]
     #[test]
     fn test_parse_response_verified() {
         let response = VerificationResponse::new(
@@ -166,6 +168,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "ch_vat")]
     #[test]
     fn test_parse_response_unverified() {
         let response = VerificationResponse::new(
@@ -190,6 +193,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "ch_vat")]
     #[test]
     fn test_parse_response_unavailable() {
         let response = VerificationResponse::new(
@@ -226,6 +230,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "ch_vat")]
     #[test]
     fn test_parse_response_unavailable_unexpected_faultstring() {
         let response = VerificationResponse::new(
@@ -253,6 +258,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "ch_vat")]
     #[test]
     fn test_parse_response_unexpected_response_value() {
         let response = VerificationResponse::new(
@@ -279,6 +285,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "ch_vat")]
     #[test]
     fn test_parse_response_empty_response_value() {
         let response = VerificationResponse::new(

--- a/src/ch_vat/mod.rs
+++ b/src/ch_vat/mod.rs
@@ -43,6 +43,7 @@ impl TaxIdType for ChVat {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "ch_vat")]
     #[test]
     fn test_ch_vats() {
         let valid_vat_numbers = vec![

--- a/src/eu_vat/mod.rs
+++ b/src/eu_vat/mod.rs
@@ -65,6 +65,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_at_vat() {
         let valid_vat_numbers = vec!["ATU12345678", "ATU87654321"];
@@ -73,6 +74,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_be_vat() {
         let valid_vat_numbers = vec!["BE0123456789", "BE0987654321"];
@@ -86,6 +88,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_bg_vat() {
         let valid_vat_numbers = vec!["BG123456789", "BG1234567890"];
@@ -94,6 +97,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_cy_vat() {
         let valid_vat_numbers = vec!["CY12345678A", "CY98765432Z"];
@@ -102,6 +106,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_cz_vat() {
         let valid_vat_numbers = vec!["CZ12345678", "CZ123456789", "CZ1234567890"];
@@ -110,6 +115,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_de_vat() {
         let valid_vat_numbers = vec!["DE123456789", "DE987654321"];
@@ -118,6 +124,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_dk_vat() {
         let valid_vat_numbers = vec!["DK12345678"];
@@ -126,6 +133,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_ee_vat() {
         let valid_vat_numbers = vec!["EE101234567"];
@@ -134,6 +142,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_el_vat() {
         let valid_vat_numbers = vec!["EL123456789"];
@@ -142,6 +151,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_es_vat() {
         let valid_vat_numbers = vec!["ESX12345678", "ES12345678Z", "ESX1234567Z"];
@@ -150,6 +160,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_fi_vat() {
         let valid_vat_numbers = vec!["FI12345678"];
@@ -158,6 +169,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_fr_vat() {
         let valid_vat_numbers = vec!["FR12345678901", "FRX1234567890"];
@@ -166,6 +178,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_hr_vat() {
         let valid_vat_numbers = vec!["HR12345678901"];
@@ -174,6 +187,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_hu_vat() {
         let valid_vat_numbers = vec!["HU12345678"];
@@ -182,6 +196,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_ie_vat() {
         let valid_vat_numbers = vec!["IE1234567A", "IE1A23456A", "IE1234567AA"];
@@ -190,6 +205,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_it_vat() {
         let valid_vat_numbers = vec!["IT12345678901"];
@@ -198,6 +214,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_lt_vat() {
         let valid_vat_numbers = vec!["LT999999919", "LT999999919"];
@@ -206,6 +223,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_lu_vat() {
         let valid_vat_numbers = vec!["LU12345678"];
@@ -214,6 +232,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_lv_vat() {
         let valid_vat_numbers = vec!["LV12345678901"];
@@ -222,6 +241,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_mt_vat() {
         let valid_vat_numbers = vec!["MT12345678"];
@@ -230,6 +250,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_nl_vat() {
         let valid_vat_numbers = vec!["NL123456789B01"];
@@ -238,6 +259,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_pl_vat() {
         let valid_vat_numbers = vec!["PL1234567890"];
@@ -246,6 +268,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_pt_vat() {
         let valid_vat_numbers = vec!["PT123456789"];
@@ -254,6 +277,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_ro_vat() {
         let valid_vat_numbers = vec!["RO99999999", "RO999999999"];
@@ -262,6 +286,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_se_vat() {
         let valid_vat_numbers = vec!["SE123456789101"];
@@ -270,6 +295,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_si_vat() {
         let valid_vat_numbers = vec!["SI12345678"];
@@ -278,6 +304,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_sk_vat() {
         let valid_vat_numbers = vec!["SK1234567890"];
@@ -286,6 +313,7 @@ mod tests {
         assert_validations(valid_vat_numbers, invalid_vat_numbers);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_xi_vat() {
         let valid_vat_numbers = vec!["XI123456789", "XI987654321", "XIHA123", "XIGD123"];

--- a/src/eu_vat/syntax.rs
+++ b/src/eu_vat/syntax.rs
@@ -42,6 +42,8 @@ lazy_static! {
 mod tests {
     use super::*;
     use crate::eu_vat::COUNTRIES;
+
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_each_eu_country_has_a_regex() {
         let mut eu_regex_countries = EU_VAT_PATTERNS.keys().collect::<Vec<&String>>();

--- a/src/eu_vat/vies.rs
+++ b/src/eu_vat/vies.rs
@@ -155,6 +155,7 @@ impl Verifier for Vies {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_xml_to_hash() {
         let xml = r#"
@@ -183,6 +184,7 @@ mod tests {
         assert_eq!(hash.get("address"), Some(&None));
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_parse_response_verified() {
         let response = VerificationResponse::new(
@@ -209,6 +211,7 @@ mod tests {
         assert_eq!(verification.status(), &VerificationStatus::Verified);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_parse_response_unverified() {
         let response = VerificationResponse::new(
@@ -235,6 +238,7 @@ mod tests {
         assert_eq!(verification.status(), &VerificationStatus::Unverified);
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_parse_response_unavailable() {
         let response = VerificationResponse::new(
@@ -261,6 +265,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_parse_response_missing_valid_field() {
         let response = VerificationResponse::new(
@@ -287,6 +292,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "eu_vat")]
     #[test]
     fn test_parse_response_invalid_validity_value() {
         let response = VerificationResponse::new(

--- a/src/gb_vat/hmrc.rs
+++ b/src/gb_vat/hmrc.rs
@@ -11,6 +11,7 @@ use crate::verification::UnavailableReason::ServiceUnavailable;
 
 static BASE_URI: &'static str = "https://api.service.hmrc.gov.uk/organisations/vat/check-vat-number/lookup";
 const NOT_FOUND: &str = "NOT_FOUND";
+#[allow(dead_code)]
 const SERVER_ERROR: &str = "SERVER_ERROR";
 
 
@@ -69,6 +70,7 @@ impl Verifier for Hmrc {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "gb_vat")]
     #[test]
     fn test_parse_response_verified() {
         let response = VerificationResponse::new(
@@ -108,6 +110,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "gb_vat")]
     #[test]
     fn test_parse_response_unverified() {
         let response = VerificationResponse::new(
@@ -128,6 +131,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "gb_vat")]
     #[test]
     fn test_parse_response_unavailable() {
         let response = VerificationResponse::new(

--- a/src/gb_vat/mod.rs
+++ b/src/gb_vat/mod.rs
@@ -45,6 +45,7 @@ mod tests {
     use crate::gb_vat::GbVat;
     use crate::TaxIdType;
 
+    #[cfg(feature = "gb_vat")]
     #[test]
     fn test_gb_vat() {
         let valid_vat_numbers = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,6 @@ trait TaxIdType {
     }
     fn country_code_from_tax_country(&self, tax_country_code: &str) -> String;
     fn verifier(&self) -> Box<dyn Verifier>;
-    fn verify(&self, tax_id: &TaxId) -> Result<Verification, VerificationError> {
-        self.verifier().verify(tax_id)
-    }
 }
 
 pub struct TaxId {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl TaxId {
 
     /// Performs a request to verify the tax id against the corresponding government database.
     pub fn verify(&self) -> Result<Verification, VerificationError> {
-        self.id_type.verifier().verify(self)
+        self.id_type().verifier().verify(self)
     }
 
     /// Returns the full tax id value. IE: SE556703748501

--- a/src/no_vat/brreg.rs
+++ b/src/no_vat/brreg.rs
@@ -113,6 +113,7 @@ impl Verifier for BrReg {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "no_vat")]
     #[test]
     fn test_parse_response_verified() {
         let response = VerificationResponse::new(
@@ -162,6 +163,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "no_vat")]
     #[test]
     fn test_parse_response_unverified_due_to_not_found() {
         let response = VerificationResponse::new(
@@ -175,6 +177,7 @@ mod tests {
         assert_eq!(verification.data(), &json!({}));
     }
 
+    #[cfg(feature = "no_vat")]
     #[test]
     fn test_parse_response_unverified_due_to_qualification() {
         let response = VerificationResponse::new(
@@ -202,6 +205,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "no_vat")]
     #[test]
     fn test_parse_response_unverified_due_to_deleted() {
         let response = VerificationResponse::new(
@@ -223,6 +227,7 @@ mod tests {
         assert_eq!(verification.data(), &json!({}));
     }
 
+    #[cfg(feature = "no_vat")]
     #[test]
     fn test_parse_response_unavailable() {
         let response = VerificationResponse::new(
@@ -252,6 +257,7 @@ mod tests {
         }));
     }
 
+    #[cfg(feature = "no_vat")]
     #[test]
     fn test_parse_response_unexpected_status_code() {
         let response = VerificationResponse::new(

--- a/src/no_vat/mod.rs
+++ b/src/no_vat/mod.rs
@@ -46,6 +46,7 @@ impl TaxIdType for NoVat {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "no_vat")]
     #[test]
     fn test_extract_org_number() {
         let tax_id = TaxId::new("NO123456789MVA").unwrap();
@@ -53,6 +54,7 @@ mod tests {
         assert_eq!(NoVat::extract_org_number(&NoVat, &tax_id), "123456789");
     }
 
+    #[cfg(feature = "no_vat")]
     #[test]
     fn test_no_vats() {
         let valid_vat_numbers = vec![

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -123,22 +123,37 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_verify() {
-        #[cfg(feature="eu_vat")]
-        let value = "SE123456789101";
-        #[cfg(feature="gb_vat")]
-        let value = "GB123456789";
-        #[cfg(feature="ch_vat")]
-        let value = "CHE123456789";
-        #[cfg(feature = "no_vat")]
-        let value = "NO123456789";
-        
+    fn test_verify_for(value: &str) {
         let tax_id = TaxId::new(value).unwrap();
         let verifier = TestVerifier;
         let verification = verifier.verify(&tax_id).unwrap();
         assert_eq!(verification.status(), &VerificationStatus::Verified);
         assert_eq!(verification.performed_at.date_naive(), Local::now().date_naive());
         assert_eq!(verification.data().get("key").unwrap(), "value");
+    }
+
+
+    #[cfg(feature="eu_vat")]
+    #[test]
+    fn test_verify_for_eu() {
+        test_verify_for("SE123456789101");
+    }
+
+    #[cfg(feature="gb_vat")]
+    #[test]
+    fn test_verify_for_gb() {
+        test_verify_for("GB123456789");
+    }
+
+    #[cfg(feature="ch_vat")]
+    #[test]
+    fn test_verify_for_ch() {
+        test_verify_for("CHE123456789");
+    }
+
+    #[cfg(feature="no_vat")]
+    #[test]
+    fn test_verify_for_no() {
+        test_verify_for("NO123456789");
     }
 }


### PR DESCRIPTION
### Why?

Modules/features tests were not explicitly tagged

### What changed?

- Added feature conditions to these tests
- Fixed a warning regarding `TaxIdTrait.verify()`. Removed as it was not in use.
- Fixed a warning regarding `id_type()` not being in use. Made sure to use the getter instead of the struct attribute.
- Fixed a warning for an unused constant Hmrc `SERVER_ERROR` by allowing dead code (used in tests)